### PR TITLE
Use original Error.prototype.toString for formating Error.stack

### DIFF
--- a/include/hermes/VM/JSError.h
+++ b/include/hermes/VM/JSError.h
@@ -89,6 +89,11 @@ class JSError final : public JSObject {
       Handle<JSObject> selfHandle,
       Runtime &runtime);
 
+  /// Implements steps 3 through 9 for ES2023 20.5.3.4 Error.prototype.toString.
+  static CallResult<Handle<StringPrimitive>> toString(
+      Handle<JSObject> O,
+      Runtime &runtime);
+
   /// Set the message property.
   static ExecutionStatus
   setMessage(Handle<JSError> selfHandle, Runtime &runtime, Handle<> message);
@@ -182,7 +187,7 @@ class JSError final : public JSObject {
   /// refer to the same object.
   /// In the `target = {}; Error.captureErrorStack(target); target.stack` case,
   /// selfHandle will be the value of `target`'s [[CapturedError]] slot.
-  static ExecutionStatus constructStackTraceString(
+  static ExecutionStatus constructStackTraceString_RJS(
       Runtime &runtime,
       Handle<JSError> selfHandle,
       Handle<JSObject> targetHandle,

--- a/lib/VM/JSError.cpp
+++ b/lib/VM/JSError.cpp
@@ -16,6 +16,7 @@
 #include "hermes/VM/PropertyAccessor.h"
 #include "hermes/VM/RuntimeModule-inline.h"
 #include "hermes/VM/StackFrame-inline.h"
+#include "hermes/VM/StringBuilder.h"
 #include "hermes/VM/StringView.h"
 
 #include "llvh/ADT/ScopeExit.h"
@@ -138,7 +139,7 @@ errorStackGetter(void *, Runtime &runtime, NativeArgs args) {
     }
     stackTraceFormatted = std::move(*prepareRes);
   } else {
-    if (JSError::constructStackTraceString(
+    if (JSError::constructStackTraceString_RJS(
             runtime, errorHandle, targetHandle, stack) ==
         ExecutionStatus::EXCEPTION) {
       return ExecutionStatus::EXCEPTION;
@@ -276,6 +277,86 @@ ExecutionStatus JSError::setupStack(
   }
 
   return ExecutionStatus::RETURNED;
+}
+
+CallResult<Handle<StringPrimitive>> JSError::toString(
+    Handle<JSObject> O,
+    Runtime &runtime) {
+  // 20.5.3.4 Error.prototype.toString ( )
+
+  // 1. and 2. don't apply -- O is already an Object.
+
+  // 3. Let name be ? Get(O, "name").
+  auto propRes = JSObject::getNamed_RJS(
+      O, runtime, Predefined::getSymbolID(Predefined::name), PropOpFlags());
+  if (LLVM_UNLIKELY(propRes == ExecutionStatus::EXCEPTION)) {
+    return ExecutionStatus::EXCEPTION;
+  }
+  Handle<> name = runtime.makeHandle(std::move(*propRes));
+
+  // 4. If name is undefined, set name to "Error"; otherwise set name to ?
+  // ToString(name).
+  MutableHandle<StringPrimitive> nameStr{runtime};
+  if (name->isUndefined()) {
+    nameStr = runtime.getPredefinedString(Predefined::Error);
+  } else {
+    auto strRes = toString_RJS(runtime, name);
+    if (LLVM_UNLIKELY(strRes == ExecutionStatus::EXCEPTION)) {
+      return ExecutionStatus::EXCEPTION;
+    }
+    nameStr = strRes->get();
+  }
+
+  // 5. Let msg be ? Get(O, "message").
+  if (LLVM_UNLIKELY(
+          (propRes = JSObject::getNamed_RJS(
+               O,
+               runtime,
+               Predefined::getSymbolID(Predefined::message),
+               PropOpFlags())) == ExecutionStatus::EXCEPTION)) {
+    return ExecutionStatus::EXCEPTION;
+  }
+  Handle<> msg = runtime.makeHandle(std::move(*propRes));
+
+  // 6. If msg is undefined, set msg to the empty String;
+  //    otherwise set msg to ? ToString(msg).
+  MutableHandle<StringPrimitive> msgStr{runtime};
+  if (msg->isUndefined()) {
+    // If msg is undefined, then let msg be the empty String.
+    msgStr = runtime.getPredefinedString(Predefined::emptyString);
+  } else {
+    auto strRes = toString_RJS(runtime, msg);
+    if (LLVM_UNLIKELY(strRes == ExecutionStatus::EXCEPTION)) {
+      return ExecutionStatus::EXCEPTION;
+    }
+    msgStr = strRes->get();
+  }
+
+  // 7. If name is the empty String, return msg.
+  if (nameStr->getStringLength() == 0) {
+    return msgStr;
+  }
+
+  // 8. If msg is the empty String, return name.
+  if (msgStr->getStringLength() == 0) {
+    return nameStr;
+  }
+
+  // 9. Return the string-concatenation of name, the code unit 0x003A (COLON),
+  // the code unit 0x0020 (SPACE), and msg.
+  SafeUInt32 length{nameStr->getStringLength()};
+  length.add(2);
+  length.add(msgStr->getStringLength());
+  CallResult<StringBuilder> builderRes =
+      StringBuilder::createStringBuilder(runtime, length);
+  if (LLVM_UNLIKELY(builderRes == ExecutionStatus::EXCEPTION)) {
+    return ExecutionStatus::EXCEPTION;
+  }
+  auto builder = std::move(*builderRes);
+  builder.appendStringPrim(nameStr);
+  builder.appendASCIIRef({": ", 2});
+  builder.appendStringPrim(msgStr);
+  return builder.getStringPrimitive();
 }
 
 ExecutionStatus JSError::setMessage(
@@ -535,27 +616,62 @@ bool JSError::appendFunctionNameAtIndex(
   return true;
 }
 
-ExecutionStatus JSError::constructStackTraceString(
+ExecutionStatus JSError::constructStackTraceString_RJS(
     Runtime &runtime,
     Handle<JSError> selfHandle,
     Handle<JSObject> targetHandle,
     SmallU16String<32> &stack) {
+  // This method potentially runs javascript, so we need to protect it agains
+  // stack overflow.
+  ScopedNativeDepthTracker depthTracker(runtime);
+  if (LLVM_UNLIKELY(depthTracker.overflowed())) {
+    return runtime.raiseStackOverflow(Runtime::StackOverflowKind::NativeStack);
+  }
+
   GCScope gcScope(runtime);
-  // First of all, the stacktrace string starts with target.toString.
-  auto res = toString_RJS(runtime, targetHandle);
+  // First of all, the stacktrace string starts with
+  // %Error.prototype.toString%(target).
+  CallResult<Handle<StringPrimitive>> res =
+      JSError::toString(targetHandle, runtime);
+  // Keep track whether targetHandle.toString() threw. If it did, the error
+  // message will contain a string letting the user know that something went
+  // awry.
+  const bool targetHandleToStringThrew = res == ExecutionStatus::EXCEPTION;
+
   if (LLVM_UNLIKELY(res == ExecutionStatus::EXCEPTION)) {
+    // target.toString() threw an exception; if it is a catchable error try to
+    // toString() it so the user has some indication of what went wrong.
+    if (!isUncatchableError(runtime.getThrownValue())) {
+      HermesValue thrownValue = runtime.getThrownValue();
+      if (thrownValue.isObject()) {
+        // Clear the pending exception, and try to convert thrownValue to string
+        // with %Error.prototype.toString%(thrownValue).
+        runtime.clearThrownValue();
+        res = JSError::toString(
+            runtime.makeHandle<JSObject>(thrownValue), runtime);
+      }
+    }
+  }
+
+  if (LLVM_UNLIKELY(res == ExecutionStatus::EXCEPTION)) {
+    // An exception happened while trying to get the description for the error.
     if (isUncatchableError(runtime.getThrownValue())) {
-      // If toString throws an uncatchable exception, propagate it up.
+      // If JSError::toString throws an uncatchable exception, bubble it up.
       return ExecutionStatus::EXCEPTION;
     }
-    // If toString throws an exception, we just use <error>.
-    stack.append(u"<error>");
-    // There is not much we can do if exception thrown when trying to
-    // get the stacktrace. We just name it <error>, and it should be
-    // sufficient to tell what happened here.
+    // Clear the pending exception so the caller doesn't observe this side
+    // effect.
     runtime.clearThrownValue();
+    // Append a generic <error> string and move on.
+    stack.append(u"<error>");
   } else {
+    if (targetHandleToStringThrew) {
+      stack.append(u"<while converting error to string: ");
+    }
     res->get()->appendUTF16String(stack);
+    if (targetHandleToStringThrew) {
+      stack.append(u">");
+    }
   }
 
   // Virtual offsets are computed by walking the list of bytecode functions. If

--- a/test/hermes/error-capture-stack-trace.js
+++ b/test/hermes/error-capture-stack-trace.js
@@ -27,7 +27,7 @@ function a(arg) {
 
 // Does not skip frames by default
 print(a());
-//CHECK: [object Object]
+//CHECK: Error
 //CHECK-NEXT:  at c ({{.*/error-capture-stack-trace.js}}:13:26)
 //CHECK-NEXT:  at f ({{.*/error-capture-stack-trace.js}}:19:13)
 //CHECK-NEXT:  at b ({{.*/error-capture-stack-trace.js}}:21:11)
@@ -36,7 +36,7 @@ print(a());
 
 // Skips the top frame (`c`)
 print(a(c));
-//CHECK-NEXT: [object Object]
+//CHECK-NEXT: Error
 //CHECK-NEXT:  at f ({{.*/error-capture-stack-trace.js}}:19:13)
 //CHECK-NEXT:  at b ({{.*/error-capture-stack-trace.js}}:21:11)
 //CHECK-NEXT:  at a ({{.*/error-capture-stack-trace.js}}:25:11)
@@ -44,28 +44,28 @@ print(a(c));
 
 // Skips everything down to `b`
 print(a(b));
-//CHECK-NEXT: [object Object]
+//CHECK-NEXT: Error
 //CHECK-NEXT:  at a ({{.*/error-capture-stack-trace.js}}:25:11)
 //CHECK-NEXT:  at global ({{.*/error-capture-stack-trace.js}}:46:8)
 
 // Skips everything down to `a`
 print(a(a));
-//CHECK-NEXT: [object Object]
+//CHECK-NEXT: Error
 //CHECK-NEXT:  at global ({{.*/error-capture-stack-trace.js}}:52:8)
 
 // Drills through a bound sentinel function to reach the underlying JSFunction
 var bound_a = a.bind(null);
 print(bound_a(bound_a));
-//CHECK-NEXT: [object Object]
+//CHECK-NEXT: Error
 //CHECK-NEXT:  at global ({{.*}})
 
 // Skips the entire stack if the sentinel is a function that's not found
 print(a(() => {}));
-//CHECK: [object Object]
+//CHECK: Error
 //CHECK-EMPTY
 
 // Calls toString() on the target object
-var err = {toString() { return 'Foo'; }};
+var err = {get name() { return 'Foo'; }};
 Error.captureStackTrace(err);
 print(err.stack);
 //CHECK-NEXT: Foo
@@ -99,10 +99,10 @@ captureOnInvalid(true)
 
 // Formats the stack trace lazily and caches the result
 var description = 'Foo';
-var toStringCalled = false;
-var err = {toString() { toStringCalled = true; return description; }};
+var getNameCalled = false;
+var err = {get name() { getNameCalled = true; return description; }};
 Error.captureStackTrace(err);
-print(toStringCalled);
+print(getNameCalled);
 //CHECK: false
 print(err.stack);
 //CHECK: Foo
@@ -142,10 +142,10 @@ print(Object.getOwnPropertySymbols(target).length);
 //CHECK: 0
 
 // Captures a new stack with each call.
-// Does not cache values of target.toString() between stacks
-// Also, calls target.toString() whenever a new stack needs to be rendered.
+// Does not cache values of target.name between stacks
+// Also, calls target.name whenever a new stack needs to be rendered.
 var description = 'First uncached getter call';
-var target = {toString() { return description; }};
+var target = {get name() { return description; }};
 (function firstCapture() { Error.captureStackTrace(target); })();
 (function secondCapture() { Error.captureStackTrace(target); })();
 print(target.stack);

--- a/test/hermes/regress-error-capture-stack-trace-native-constructor.js
+++ b/test/hermes/regress-error-capture-stack-trace-native-constructor.js
@@ -21,35 +21,35 @@ function DerivedError(optErrorConstructor=undefined) {
 print("BaseError()");
 print((new BaseError()).stack);
 // CHECK-LABEL: BaseError()
-// CHECK-NEXT: [object Object]
+// CHECK-NEXT: Error
 // CHECK-NEXT:     at BaseError ({{.*}}.js:14:28)
 // CHECK-NEXT:     at global ({{.*}}.js:22:21)
 
 print("BaseError(Error)");
 print((new BaseError(Error)).stack);
 // CHECK-LABEL: BaseError(Error)
-// CHECK-NEXT: [object Object]
+// CHECK-NEXT: Error
 
 print("BaseError(Error.constructor)");
 print((new BaseError(Error.constructor)).stack);
 // CHECK-LABEL: BaseError(Error.constructor)
-// CHECK-NEXT: [object Object]
+// CHECK-NEXT: Error
 
 print("BaseError(BaseError)");
 print((new BaseError(BaseError)).stack);
 // CHECK-LABEL: BaseError(BaseError)
-// CHECK-NEXT: [object Object]
+// CHECK-NEXT: Error
 // CHECK-NEXT:     at global ({{.*}}.js:39:21)
 
 print("BaseError(BaseError.constructor)");
 print((new BaseError(BaseError.constructor)).stack);
 // CHECK-LABEL: BaseError(BaseError.constructor)
-// CHECK-NEXT: [object Object]
+// CHECK-NEXT: Error
 
 print("DerivedError()");
 print((new DerivedError()).stack);
 // CHECK-LABEL: DerivedError()
-// CHECK-NEXT: [object Object]
+// CHECK-NEXT: Error
 // CHECK-NEXT:     at BaseError ({{.*}}.js:14:28)
 // CHECK-NEXT:     at apply (native)
 // CHECK-NEXT:     at DerivedError ({{.*}}.js:18:20)
@@ -58,17 +58,17 @@ print((new DerivedError()).stack);
 print("DerivedError(Error)");
 print((new DerivedError(Error)).stack);
 // CHECK-LABEL: DerivedError(Error)
-// CHECK-NEXT: [object Object]
+// CHECK-NEXT: Error
 
 print("DerivedError(Error.constructor)");
 print((new DerivedError(Error.constructor)).stack);
 // CHECK-LABEL: DerivedError(Error.constructor)
-// CHECK-NEXT: [object Object]
+// CHECK-NEXT: Error
 
 print("DerivedError(BaseError)");
 print((new DerivedError(BaseError)).stack);
 // CHECK-LABEL: DerivedError(BaseError)
-// CHECK-NEXT: [object Object]
+// CHECK-NEXT: Error
 // CHECK-NEXT:     at apply (native)
 // CHECK-NEXT:     at DerivedError ({{.*}}.js:18:20)
 // CHECK-NEXT:     at global ({{.*}}.js:69:24)
@@ -76,15 +76,15 @@ print((new DerivedError(BaseError)).stack);
 print("DerivedError(BaseError.constructor)");
 print((new DerivedError(BaseError.constructor)).stack);
 // CHECK-LABEL: DerivedError(BaseError.constructor)
-// CHECK-NEXT: [object Object]
+// CHECK-NEXT: Error
 
 print("DerivedError(DerivedError)");
 print((new DerivedError(DerivedError)).stack);
 // CHECK-LABEL: DerivedError(DerivedError)
-// CHECK-NEXT: [object Object]
+// CHECK-NEXT: Error
 // CHECK-NEXT:     at global ({{.*}}.js:82:24)
 
 print("DerivedError(DerivedError.constructor)");
 print((new DerivedError(DerivedError.constructor)).stack);
 // CHECK-LABEL: DerivedError(DerivedError.constructor)
-// CHECK-NEXT: [object Object]
+// CHECK-NEXT: Error

--- a/test/hermes/regress-error-stack-native-stack-overflow.js
+++ b/test/hermes/regress-error-stack-native-stack-overflow.js
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RUN: %hermes -O0 %s | %FileCheck --match-full-lines %s
+// RUN: %hermes -O %s  | %FileCheck --match-full-lines %s
+
+"use strict";
+
+function test(description, createErr) {
+    print(description);
+    print(createErr().stack);
+}
+
+test("overriding toString", () => {
+    var err = new Error("overriding toString");
+    err.toString = function() { return this.stack; };
+    return err;
+});
+// CHECK-LABEL: overriding toString
+// CHECK-NEXT: Error: overriding toString
+// CHECK-NEXT:     at anonymous ({{.*}}.js:19:24)
+// CHECK-NEXT:     at test ({{.*}}.js:15:20)
+// CHECK-NEXT:     at global ({{.*}}.js:18:5)
+
+test("overriding name getter", () => {
+    var err = new Error("overriding name getter");
+    Object.defineProperty(err, "name", {get: function() { return this.stack; }});
+    return err;
+});
+// CHECK-LABEL: overriding name getter
+// CHECK-NEXT: <while converting error to string: RangeError: Maximum call stack size exceeded (native stack depth)>
+// CHECK-NEXT:     at anonymous ({{.*}}.js:30:24)
+// CHECK-NEXT:     at test ({{.*}}.js:15:20)
+// CHECK-NEXT:     at global ({{.*}}.js:29:5): overriding name getter
+// CHECK-NEXT:     at anonymous ({{.*}}.js:30:24)
+// CHECK-NEXT:     at test ({{.*}}.js:15:20)
+// CHECK-NEXT:     at global ({{.*}}.js:29:5): overriding name getter
+
+test("overriding message getter", () => {
+    var err = new Error("overriding message getter");
+    Object.defineProperty(err, "message", {get: function() { return this.stack; }});
+    return err;
+});
+// CHECK-LABEL: overriding message getter
+// CHECK-NEXT: Error: Error: {{.*}}: <while converting error to string: RangeError: Maximum call stack size exceeded (native stack depth)>
+// CHECK-NEXT:     at anonymous ({{.*}}.js:44:24)
+// CHECK-NEXT:     at test ({{.*}}.js:15:20)
+// CHECK-NEXT:     at global ({{.*}}.js:43:5)
+// CHECK-NEXT:     at anonymous ({{.*}}.js:44:24)
+// CHECK-NEXT:     at test ({{.*}}.js:15:20)
+// CHECK-NEXT:     at global ({{.*}}.js:43:5)
+
+test("Object.toString => this.stack", () => {
+    var o = { toString: function() { return this.stack; } };
+    Error.captureStackTrace(o);
+    return o;
+});
+
+test("Object.name => this.stack", () => {
+    var o = { get name() { return this.stack; } };
+    Error.captureStackTrace(o);
+    return o;
+});
+
+test("Object.message => this.stack", () => {
+    var o = { get message() { return this.stack; } };
+    Error.captureStackTrace(o);
+    return o;
+});
+
+test("Object.toString throws", () => {
+    var o = { toString: function() { throw new Error("toString throws"); } };
+    Error.captureStackTrace(o);
+    return o;
+});
+
+test("Object.name throws", () => {
+    var o = { get name() { throw new Error("name getter throws"); } };
+    Error.captureStackTrace(o);
+    return o;
+});
+
+test("Object.message throws", () => {
+    var o = { get message() { throw new Error("message getter throws"); } };
+    Error.captureStackTrace(o);
+    return o;
+});
+
+test("Object.__proto__.toString => this.stack", () => {
+    var p = { toString: function() { return this.stack; } };
+    var o = { __proto__: p };
+    Error.captureStackTrace(o);
+    return o;
+});
+
+test("Object.__proto__.name => this.stack", () => {
+    var p = { get name() { return this.stack; } };
+    var o = { __proto__: p };
+    Error.captureStackTrace(o);
+    return o;
+});
+
+test("Object.__proto__.message => this.stack", () => {
+    var p = { get name() { return this.stack; } };
+    var o = { __proto__: p };
+    Error.captureStackTrace(o);
+    return o;
+});
+
+test("Object.name getter throws err; err.name is string", () => {
+    var o = { get name() { throw  {name: "123" }; } };
+    Error.captureStackTrace(o);
+    return o;
+});
+
+test("Object.name getter throws err; err.name is not string", () => {
+    var o = { get name() { throw { name: 123 }; } };
+    Error.captureStackTrace(o);
+    return o;
+});
+
+test("Object.name getter throws err; err.message is string", () => {
+    var o = { get name() { throw  {message: "123" }; } };
+    Error.captureStackTrace(o);
+    return o;
+});
+
+test("Object.name getter throws err; err.message is not string", () => {
+    var o = { get name() { throw { message: 123 }; } };
+    Error.captureStackTrace(o);
+    return o;
+});
+
+test("Object.message getter throws err; err.message is string", () => {
+    var o = { get message() { throw  {message: "123" }; } };
+    Error.captureStackTrace(o);
+    return o;
+});
+
+test("Object.message getter throws err; err.name is string, err.message is not string", () => {
+    var o = { get message() { throw { name: "object name", message: 123 }; } };
+    Error.captureStackTrace(o);
+    return o;
+});

--- a/test/hermes/uncatchable-error-to-string.js
+++ b/test/hermes/uncatchable-error-to-string.js
@@ -11,12 +11,10 @@
 print('Start');
 // CHECK-LABEL: Start
 
-// Overwrite all type errors to quit upon calling toString.
-// Note that it's very important not to overwrite Error.prototype.toString,
+// Overwrite all type errors to quit upon getting name.
+// Note that it's very important not to overwrite Error.name,
 // since QuitError's prototype is Error.
-TypeError.prototype.toString = function() {
-  quit();
-};
+Object.defineProperty(TypeError.prototype, "name", {get: quit});
 
 // QuitError should be uncatchable, and should not be removed by native code.
 // In this case, JS.stack is native code.


### PR DESCRIPTION
Summary:
Use the original Error.prototype.toString (as defined in ES2023 20.5.3.4) to format Error.stack. Also make sure a runaway recursion while formatting the stack does not bring the VM down. Finally, try to scrape any exceptions raised while formatting the stack trace so the user can get some information that an error happened (this last item leads to poor developer experience when there is an infinite recursion while formatting the stack).

Reviewed By: newobj

Differential Revision: D44258504

fbshipit-source-id: 772ae8225bfb1128cc6abadea75f5163714e70a5

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/hermes) and create your branch from `main`.
  2. If you've fixed a bug or added code that should be tested, add tests!
  3. Ensure it builds and the test suite passes. [tips](https://github.com/facebook/hermes/blob/HEAD/doc/BuildingAndRunning.md)
  4. Format your code with `.../hermes/utils/format.sh`
  5. If you haven't already, complete the CLA.
-->

## Summary

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
-->

## Test Plan

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes the user interface.
-->
